### PR TITLE
[v2.0.10] Release Branch

### DIFF
--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -167,6 +167,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: workaround for weird head refs
+        shell: bash
+        run: |
+          git checkout ${GITHUB_REF}
       - uses: ./.github/actions/execute-job-image
         name: "execute job-image action"
   promote-to-passed:

--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -159,6 +159,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.GH_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.GH_AWS_SECRET_ACCESS_KEY }}
       AWS_EC2_METADATA_DISABLED: true
+      AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
       DEV_REGISTRY: ${{ secrets.DEV_REGISTRY }}
       DOCKER_USERNAME: ${{ secrets.GH_DOCKER_BUILD_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.GH_DOCKER_BUILD_TOKEN }}

--- a/docs/yaml/versions.yml
+++ b/docs/yaml/versions.yml
@@ -1,2 +1,2 @@
-version: 2.0.2-ea
+version: 2.0.10
 quoteVersion: 0.4.1


### PR DESCRIPTION

All commits that are going out in 2.0.10 release **must** be on rel/v2.0.10.
This will allow the appropriate CI to run.

Reviewers, please review the changelog and commits in this branch to make sure everything that needs to go out in the release is on this branch.

Each push to this branch will generate a new RC tag.
