### PR TITLE
[v2.0.13] Changelog date update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
-## [2.0.13] (TBD)
+## [2.0.13] September 10, 2021
 [2.0.13]: https://github.com/emissary-ingress/emissary/releases/v2.0.13
 
 We're pleased to introduce Emissary-ingress 2.0.3 as a _developer preview_. The 2.X family


### PR DESCRIPTION
Changelog date updates for 2.0.13

Reviewers: The only changes in this PR should be updating the changelog entry for 2.0.13 to the date it was released.

If there are any other changes, the PR creator should note the reason.