### PR TITLE
[v2.0.3-ea] Release Branch

### DIFF
--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -12,14 +12,6 @@ on:
       - 'docs/**'
       - '*.md$'
   pull_request:
-    paths-ignore:
-      - 'releng/**'
-      - 'charts/**'
-      - 'manifests/**'
-      - 'k8s-config/**'
-      - 'docs/**'
-      - '*.md$'
-  pull_request:
     branches:
       - master
       - release/v*

--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -19,6 +19,10 @@ on:
       - 'k8s-config/**'
       - 'docs/**'
       - '*.md$'
+  pull_request:
+    branches:
+      - master
+      - release/v*
 
 jobs:
   lint-test:

--- a/docs/yaml/versions.yml
+++ b/docs/yaml/versions.yml
@@ -1,2 +1,2 @@
-version: 2.0.2-ea
+version: 2.0.3-ea
 quoteVersion: 0.4.1


### PR DESCRIPTION

All commits that are going out in 2.0.3-ea release **must** be on rel/v2.0.3-ea.
This will allow the appropriate CI to run.

Reviewers, please review the changelog and commits in this branch to make sure everything that needs to go out in the release is on this branch.

Each push to this branch will generate a new RC tag.
