### PR TITLE
[v2.0.5-ea] Release Branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,20 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
+## [2.0.5-ea] (TBD)
+[2.0.5-ea]: https://github.com/emissary-ingress/emissary/releases/v2.0.5-ea
+
+We're pleased to introduce Emissary-ingress 2.0.3 as a _developer preview_. The 2.X family
+introduces a number of changes to allow Emissary-ingress to more gracefully handle larger
+installations, reduce global configuration to better handle multitenant or multiorganizational
+installations, reduce memory footprint, and improve performance. We welcome feedback!! Join us on
+<a href="https://a8r.io/slack">Slack</a> and let us know what you think.
+
+## Emissary-ingress
+
+- Bugfix: The release now shows its actual released version number, rather than the internal development
+  version number.
+
 ## [2.0.4-ea] (TBD)
 [2.0.4-ea]: https://github.com/emissary-ingress/emissary/releases/v2.0.4-ea
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -29,6 +29,21 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 2.0.5-ea
+    date: "TBD"
+    notes:
+      - title: Developer Preview!
+        body: We're pleased to introduce $productName$ 2.0.3 as a <b>developer preview</b>. The 2.X family introduces a number of changes to allow $productName$ to more gracefully handle larger installations, reduce global configuration to better handle multitenant or multiorganizational installations, reduce memory footprint, and improve performance. We welcome feedback!! Join us on <a href="https://a8r.io/slack">Slack</a> and let us know what you think.
+        type: change
+        isHeadline: true
+        docs: about/changes-2.0.0
+
+      - type: bugfix
+        title: Hello World!
+        body: >-
+          The release now shows its actual released version number, rather than
+          the internal development version number.
+
   - version: 2.0.4-ea
     date: "TBD"
     notes:

--- a/docs/yaml/versions.yml
+++ b/docs/yaml/versions.yml
@@ -1,2 +1,2 @@
-version: 2.0.2-ea
+version: 2.0.5-ea
 quoteVersion: 0.4.1


### PR DESCRIPTION

All commits that are going out in 2.0.5-ea release **must** be on rel/v2.0.5-ea.
This will allow the appropriate CI to run.

Reviewers, please review the changelog and commits in this branch to make sure everything that needs to go out in the release is on this branch.

Each push to this branch will generate a new RC tag.
